### PR TITLE
Fix Servfail on malformed query

### DIFF
--- a/dnstrace_test.go
+++ b/dnstrace_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func BenchmarkMessageRaw(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var m dns.Msg
+		m.RecursionDesired = true
+		m.Question = make([]dns.Question, 1)
+		question := dns.Question{"", dns.TypeA, dns.ClassINET}
+		m.Question[0] = question
+		rando := rand.New(rand.NewSource(time.Now().Unix()))
+		m.Id = uint16(rando.Uint32())
+		// create a new lock free rand source for this goroutine
+	}
+}
+
+func BenchmarkMsgWrapped(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var m dns.Msg
+		m.SetQuestion("www.ucla.edu", dns.TypeA)
+	}
+}


### PR DESCRIPTION

Modifying dns.msg directly seems to produce broken DNS query, causing SERVFAIL from server.  I modified to use dns.Msg API , and it's fixed. 

I put the before BEFORE and AFTER below. Also added a benchmark to make sure using API did not regress performance. 

### Known Bugs
* pRecurse is not being set properly. will fix before merging



## AFTER 


### SERVFAIL count = 0
```
# this branch
$ go run . -s 192.168.1.1 www.ucla.edu
Benchmarking 192.168.1.1:53 via udp with 1 concurrent requests


Total requests:  1 of 1 (100.0%)
DNS success codes:      1

DNS response codes
        NOERROR:        1
```

### Test with NC

```
 nc -lup 5353 | hexdump -c
0000000      M 001  \0  \0 001  \0  \0  \0  \0  \0  \0 004   u   c   l

0000010   a 003   e   d   u  \0  \0 001  \0 001
000001a
```


## BEFORE 

### SERVFAIL count = 1

```
tonymet@DESKTOP-51A0S7U:~/go/src/github.com/redsift/dnstrace$ git checkout master
Switched to branch 'master'
$ go run . -s 192.168.1.1 www.ucla.edu
Benchmarking 192.168.1.1:53 via udp with 1 concurrent requests
Total requests:  1 of 1 (100.0%)
DNS success codes:      0

DNS response codes
        SERVFAIL:       1
```

### TEST Query with NC

```
nc -lup 5353 | hexdump -c
0000000   ] 020  \0  \0  \0 001  \0  \0  \0  \0  \0  \0 004   u   c   l

0000010   a 003   e   d   u  \0  \0 001  \0 001
000001a
```

## Bench mark "raw" (BEFORE) vs "wrapped" (AFTER)
raw = 933ns/op & 3 allocs
wrapped = 10759 ns/op & 1 alloc

```


tonymet@DESKTOP-51A0S7U:~/go/src/github.com/redsift/dnstrace$ go test -test.bench  .
goos: linux
goarch: amd64
pkg: github.com/redsift/dnstrace
cpu: Intel(R) Core(TM) i5-8500T CPU @ 2.10GHz
BenchmarkMessageRaw-6             110208             10759 ns/op            5376 B/op          1 allocs/op
BenchmarkMsgWrapped-6            1303633               933.0 ns/op            28 B/op          3 allocs/op
PASS
ok      github.com/redsift/dnstrace     3.454s

```